### PR TITLE
fix: add dark theme color definitions

### DIFF
--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -15,13 +15,7 @@ export const Colors = {
     tabIconDefault: '#687076',
     tabIconSelected: tintColorLight,
   },
-  // Added common colors used outside of light/dark modes
-  primary: '#007BFF', // Placeholder for primary color
-  cardBackground: '#FFFFFF', // Placeholder for card background
-  lightGray: '#E0E0E0', // Placeholder for light gray
-  textPrimary: '#333333', // Placeholder for primary text color
-  textSecondary: '#666666', // Placeholder for secondary text color
-  error: '#FF0000', // Placeholder for error color
+  dark: {
     text: '#ECEDEE',
     background: '#151718',
     tint: tintColorDark,
@@ -29,4 +23,12 @@ export const Colors = {
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,
   },
+
+  // Added common colors used outside of light/dark modes
+  primary: '#007BFF', // Placeholder for primary color
+  cardBackground: '#FFFFFF', // Placeholder for card background
+  lightGray: '#E0E0E0', // Placeholder for light gray
+  textPrimary: '#333333', // Placeholder for primary text color
+  textSecondary: '#666666', // Placeholder for secondary text color
+  error: '#FF0000', // Placeholder for error color
 };


### PR DESCRIPTION
## Summary
- include missing `dark` color palette in constants to enable theme switching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689990a175a48320b3985b2aef11d014